### PR TITLE
boot: Add config for Ubuntu 20.10 64Bit

### DIFF
--- a/boot/config-normal-20.10-64.txt
+++ b/boot/config-normal-20.10-64.txt
@@ -1,0 +1,27 @@
+[pi4]
+kernel=uboot_rpi_4.bin
+max_framebuffers=2
+
+[pi2]
+kernel=uboot_rpi_2.bin
+
+[pi3]
+kernel=uboot_rpi_3.bin
+
+[all]
+arm_64bit=1
+device_tree_address=0x03000000
+
+# The following settings are "defaults" expected to be overridden by the
+# included configuration. The only reason they are included is, again, to
+# support old firmwares which don't understand the "include" command.
+
+enable_uart=1
+cmdline=cmdline.txt
+
+include syscfg.txt
+include usercfg.txt
+
+disable_overscan=1
+dtoverlay=vc4-fkms-v3d
+hdmi_drive=2


### PR DESCRIPTION
If a user would try to install LCD-show on Ubuntu 20.10 64Bit it would
install but upon boot they would find themselves stuck on a rainbow 
screen.